### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ADD ./prometheus_xmpp /prometheus_xmpp
 ADD ./xmpp-alerts.yml.example /etc/prometheus/xmpp-alerts.yml
 
 RUN sed -i 's/127.0.0.1/0.0.0.0/' /etc/prometheus/xmpp-alerts.yml
+RUN sed -i 's/yaml.load(f)/yaml.load(f, Loader=yaml.FullLoader)/' /prometheus-xmpp-alerts
 
 EXPOSE 9199
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7-alpine AS build-env
+
+RUN apk add --no-cache \
+  gcc \
+  musl-dev \
+  libffi-dev
+
+RUN pip install \
+  slixmpp \
+  aiohttp \
+  pyyaml \
+  prometheus_client
+
+FROM python:3.7-alpine
+
+COPY --from=build-env /usr/local/lib/python3.7/site-packages/ /usr/local/lib/python3.7/site-packages/
+
+ADD ./prometheus-xmpp-alerts /prometheus-xmpp-alerts
+ADD ./prometheus_xmpp /prometheus_xmpp
+ADD ./xmpp-alerts.yml.example /etc/prometheus/xmpp-alerts.yml
+
+RUN sed -i 's/127.0.0.1/0.0.0.0/' /etc/prometheus/xmpp-alerts.yml
+
+EXPOSE 9199
+
+CMD ["/usr/local/bin/python", "/prometheus-xmpp-alerts", "--config", "/etc/prometheus/xmpp-alerts.yml"]

--- a/prometheus-xmpp-alerts
+++ b/prometheus-xmpp-alerts
@@ -106,7 +106,7 @@ args = parser.parse_args()
 logging.basicConfig(level=args.loglevel, format='%(levelname)-8s %(message)s')
 
 with open(args.config_path) as f:
-    config = yaml.load(f, Loader=yaml.FullLoader)
+    config = yaml.load(f)
 
 app = XmppApp(config['jid'], config.get('password'),
               config.get('amtool_allowed', [config['to_jid']]))

--- a/prometheus-xmpp-alerts
+++ b/prometheus-xmpp-alerts
@@ -106,7 +106,7 @@ args = parser.parse_args()
 logging.basicConfig(level=args.loglevel, format='%(levelname)-8s %(message)s')
 
 with open(args.config_path) as f:
-    config = yaml.load(f)
+    config = yaml.load(f, Loader=yaml.FullLoader)
 
 app = XmppApp(config['jid'], config.get('password'),
               config.get('amtool_allowed', [config['to_jid']]))


### PR DESCRIPTION
Using a Docker container allows people like me, who are stuck with the Python version of their distro, to run `prometheus-xmpp-alerts` without the SSLv3 handshake warning (see #9 ).