### PR TITLE
Support a password command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ $ python3 prometheus-xmpp-alerts
 If you have [amtool](https://github.com/prometheus/alertmanager#amtool) set up,
 then you can also allow ``to_jid`` to see existing alerts and manage silences.
 
+Password Command
+----------------
+
+Instead of hardcoding your password, you can also use a `password_command`. The
+command should write the password to stdout. Only the first line (stripped of
+whitespaces) is being used as password.
+
 Message Format
 --------------
 

--- a/prometheus-xmpp-alerts
+++ b/prometheus-xmpp-alerts
@@ -10,6 +10,7 @@
 #
 # Edit xmpp-alerts.yml.example, then run:
 # $ python3 prometheus-xmpp-alerts --config=xmpp-alerts.yml.example
+import subprocess
 import argparse
 import json
 import logging
@@ -41,9 +42,27 @@ xmpp_message_counter = Counter(
     'xmpp_message_count', 'Total number of XMPP messages received.')
 
 
+def read_password_from_command(cmd):
+    """
+    Read the first line of the output of `cmd` and return the stripped string.
+    Args:
+        cmd: The command that should be executed.
+    """
+    out = subprocess.check_output(cmd, shell=True).decode('utf-8')
+    lines = out.split('\n')
+    first_line = lines[0]
+
+    return first_line.strip()
+
+
 class XmppApp(slixmpp.ClientXMPP):
 
-    def __init__(self, jid, password, amtool_allowed=None):
+    def __init__(self, jid, password, password_command=None,
+                 amtool_allowed=None):
+
+        if password_command:
+            password = read_password_from_command(password_command)
+
         slixmpp.ClientXMPP.__init__(self, jid, password)
         self._amtool_allowed = amtool_allowed or []
         self.auto_authorize = True
@@ -116,7 +135,7 @@ with open(args.config_path) as f:
 hostname = socket.gethostname()
 jid = "{}/{}".format(config['jid'], hostname)
 
-app = XmppApp(jid, config.get('password'),
+app = XmppApp(jid, config.get('password'), config.get('password_command'),
               config.get('amtool_allowed', [config['to_jid']]))
 app.connect()
 

--- a/xmpp-alerts.yml.example
+++ b/xmpp-alerts.yml.example
@@ -1,6 +1,8 @@
 # Login details for the bot itself
 jid: 'alertmanager@example.com'
 password: 'PASSWORD'
+# (optional) command that produces the password
+# password_command: 'cat /run/secrets/foo'
 listen_address: '127.0.0.1'
 listen_port: 9199
 # JID to send alerts to


### PR DESCRIPTION
This is helpful if you do not want to hardcode the password in a
configuration file. In my case the secrets are on an ephemeral
filesystem (e.g. /run/secrets) that is wiped on a reboot. I use `cat
/run/secrets/foo` to read the password.