### PR TITLE
use `amtool` from PATH and allow specifying the alertmanager url

### DIFF
--- a/prometheus-xmpp-alerts
+++ b/prometheus-xmpp-alerts
@@ -63,13 +63,14 @@ def read_password_from_command(cmd):
 class XmppApp(slixmpp.ClientXMPP):
 
     def __init__(self, jid, password, password_command=None,
-                 amtool_allowed=None):
+                 amtool_allowed=None, alertmanager_url=None):
 
         if password_command:
             password = read_password_from_command(password_command)
 
         slixmpp.ClientXMPP.__init__(self, jid, password)
         self._amtool_allowed = amtool_allowed or []
+        self.alertmanager_url = alertmanager_url
         self.auto_authorize = True
         self.add_event_handler("session_start", self.start)
         self.add_event_handler("message", self.message)
@@ -109,6 +110,8 @@ class XmppApp(slixmpp.ClientXMPP):
             elif args[0].lower() in ('alert', 'silence'):
                 args[0] = args[0].lower()
                 if msg['from'].bare in self._amtool_allowed:
+                    if self.alertmanager_url:
+                        args = [ '--alertmanager.url', self.alertmanager_url ] + args
                     response = run_amtool(args)
                 else:
                     response = "Unauthorized JID."
@@ -146,7 +149,8 @@ hostname = socket.gethostname()
 jid = "{}/{}".format(config['jid'], hostname)
 
 app = XmppApp(jid, config.get('password'), config.get('password_command'),
-              config.get('amtool_allowed', [config['to_jid']]))
+              config.get('amtool_allowed', [config['to_jid']]),
+              config.get('alertmanager_url', None))
 app.connect()
 
 

--- a/prometheus_xmpp/__init__.py
+++ b/prometheus_xmpp/__init__.py
@@ -73,6 +73,6 @@ def run_amtool(args):
     # TODO(jelmer): Support setting the current user, e.g. for silence
     # ownership.
     ret = subprocess.run(
-        ["/usr/bin/amtool"] + args, shell=False, universal_newlines=True,
+        ["amtool"] + args, shell=False, universal_newlines=True,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     return ret.stdout


### PR DESCRIPTION
On my system there is no system wide configuration for alertmanager and thus prometheus-xmpp-alerts is unable to discover the alertmanager url. This PR allows to (optionally) specify that on the CLI when starting the service. It is now also possible to have `amtool` in another directory since it will just be discovered from `PATH`. There should be no downsides for other users in this.