### PR TITLE
Tweak documentation a bit:

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use, configure a web hook in alertmanager. E.g.:
 
 ```yaml
 receivers:
-- name: 'jelmer-pager'
+- name: 'jelmer-xmpp'
   webhook_configs:
   - url: 'http://192.168.2.1:9199/alert'
 ```
@@ -20,20 +20,28 @@ Edit the configuration file (defaults to ``/etc/prometheus/xmpp-alerts.yml``):
 ```yaml
 jid: 'alertmanager@example.com'
 password: 'PASSWORD'
+# Alternatively, set a 'password_command' that should write a password to
+# stdout
+# password_command: 'pass show xmpp-alertmanager'
 to_jid: 'jelmer@example.com'
 listen_address: '192.168.2.1'
 listen_port: 9199
-format: 'short'
+
+# Text message template as jinja2; defaults to html_template with tags stripped.
+text_template: |
+ {{ status.upper() }}: *{{ labels.alertname }}* at {{ labels.host or labels.instance }}:\
+ {{ annotations.message }}. {{ generatorURL }}
 ```
 
 And run the web hook::
 
 ```shell
-$ python3 -m prometheus_xmpp
+$ python3 -m prometheus_xmpp --config=/etc/prometheus/xmpp-alerts.yaml
 ```
 
 If you have [amtool](https://github.com/prometheus/alertmanager#amtool) set up,
 then you can also allow ``to_jid`` to see existing alerts and manage silences.
+Set the ``amtool_allowed`` option to JIDs that are allowed to use amtool.
 
 Docker file
 -----------
@@ -42,28 +50,15 @@ You can build your own docker images using the Dockerfile in this directory, or
 use ``ghcr.io/jelmer/prometheus-xmpp-alerts``. Provide your configuration in
 ``/config.yaml``.
 
-Password Command
-----------------
-
-Instead of hardcoding your password, you can also use a `password_command`. The
-command should write the password to stdout. Only the first line (stripped of
-whitespaces) is being used as password.
-
 Message Format
 --------------
 
-If you don't set the message format option, the `short` format will be used.
+The default message format looks something like this:
 
-* **short**
-  > FIRING, 2019-05-17T18:48:18, Alert Summary
+  > FIRING: *AlertName* at somehost: Alert Summary. https://prometheus.example.com/expr?...
 
-* **full**
-  > **[FIRING] Alert Summary** (groupLabelValue1 groupLabelValue2)
-  > This is the description of the test alert.
-  > **label1**: value1
-  > **label2**: value2
-  > **label3**: value3
-
+The ``text_template`` option in the configuration can be used to customize the
+format, using jinja2.
 
 Testing
 -------


### PR DESCRIPTION
Tweak documentation a bit:

* Drop separate section for password_command
* Remove documentation for deprecated format option, instead document templates
