### PR TITLE
Fix outdated entrypoint definiton

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ tests_require = pytz
 
 [options.entry_points]
 console_scripts =
-    prometheus-xmpp-alerts=prometheus_xmpp_alerts:main
+    prometheus-xmpp-alerts=prometheus_xmpp.__main__:main
 
 [flake8]
 filename = prometheus_xmpp/


### PR DESCRIPTION
The defined entrypoint was broken as of (probably) #25 (6445e83dcf8aaedb655d241d47e936c3ddc8b7a4). The state of the broken entry-point can be demonstrated like so (prior to this PR):

```bash
$ cd prometheus-xmpp-alerts
$ python3 -m venv .venv
$ .venv/bin/pip3 install -e .
[…]
  Running setup.py develop for prometheus-xmpp-alerts
Successfully installed MarkupSafe-2.1.1 aiodns-3.0.0 aiohttp-3.8.3 aiohttp_openmetrics-0.0.11 aiosignal-1.3.1 async-timeout-4.0.2 attrs-22.2.0 beautifulsoup4-4.11.1 bs4-0.0.1 cffi-1.15.1 charset-normalizer-2.1.1 frozenlist-1.3.3 idna-3.4 jinja2-3.1.2 multidict-6.0.4 prometheus-client-0.15.0 prometheus-xmpp-alerts-0.5.6 pyasn1-0.4.8 pyasn1_modules-0.2.8 pycares-4.3.0 pycparser-2.21 pytz-2022.7 pyyaml-6.0 slixmpp-1.8.3 soupsieve-2.3.2.post1 yarl-1.8.2
$ .venv/bin/prometheus-xmpp-alerts --help
Traceback (most recent call last):
  File "/home/e1mo/Documents/prometheus-xmpp-alerts/.venv/bin/prometheus-xmpp-alerts", line 33, in <module>
    sys.exit(load_entry_point('prometheus-xmpp-alerts', 'console_scripts', 'prometheus-xmpp-alerts')())
  File "/home/e1mo/Documents/prometheus-xmpp-alerts/.venv/bin/prometheus-xmpp-alerts", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/nix/store/al6g1zbk8li6p8mcyp0h60d08jaahf8c-python3-3.10.9/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'prometheus_xmpp_alerts'
```

After this fix:

```bash
$ prometheus-xmpp-alerts
$ python3 -m venv .venv
$ .venv/bin/pip3 install -e .
[…]
  Running setup.py develop for prometheus-xmpp-alerts
Successfully installed MarkupSafe-2.1.1 aiodns-3.0.0 aiohttp-3.8.3 aiohttp_openmetrics-0.0.11 aiosignal-1.3.1 async-timeout-4.0.2 attrs-22.2.0 beautifulsoup4-4.11.1 bs4-0.0.1 cffi-1.15.1 charset-normalizer-2.1.1 frozenlist-1.3.3 idna-3.4 jinja2-3.1.2 multidict-6.0.4 prometheus-client-0.15.0 prometheus-xmpp-alerts-0.5.6 pyasn1-0.4.8 pyasn1_modules-0.2.8 pycares-4.3.0 pycparser-2.21 pytz-2022.7 pyyaml-6.0 slixmpp-1.8.3 soupsieve-2.3.2.post1 yarl-1.8.2
$ .venv/bin/prometheus-xmpp-alerts --help
Using slower stringprep, consider compiling the faster cython/libidn one.
usage: prometheus-xmpp-alerts [-h] [--config CONFIG_PATH] [-q] [-d]

options:
  -h, --help            show this help message and exit
  --config CONFIG_PATH  Path to configuration file.
  -q, --quiet           set logging to ERROR
  -d, --debug           set logging to DEBUG
```