### PR TITLE
Add tests for 3.11

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        exclude:
+          # There is no pyyaml wheel on macos-latest/3.9
+          - os: macos-latest
+            python-version: "3.9"
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Add tests for 3.11.

Skip macos/python3.9 test since pyyaml wheel appears to be missing.
