### PR TITLE
Add muc/omemo support

### DIFF
--- a/prometheus_xmpp/__main__.py
+++ b/prometheus_xmpp/__main__.py
@@ -20,6 +20,7 @@ import sys
 import traceback
 import asyncio
 import os
+from typing import Dict, List, Literal
 
 import slixmpp
 import yaml
@@ -254,17 +255,17 @@ class XmppApp(slixmpp.ClientXMPP):
             logging.debug("sending encrypted message to recipients %s", recipients)
             await self.send_encrypted(mto=recipients, mtype="groupchat", body=mbody)
 
-    async def send_encrypted(self, mto: JID, mtype: str, body):
+    async def send_encrypted(self, mto: JID, mtype: Literal['chat', 'error', 'groupchat', 'headline', 'normal'], body):
         """Helper to reply with encrypted messages"""
         if self.muc:
             msg = self.make_message(mto=self.muc_jid, mtype=mtype)
         else:
-            msg = self.make_message(mto=mto[0], mtype=mtype)
+            msg = self.make_message(mto=mto, mtype=mtype)
 
         msg["eme"]["namespace"] = self.eme_ns
         msg["eme"]["name"] = self["xep_0380"].mechanisms[self.eme_ns]
 
-        expect_problems = {}  # type: Optional[Dict[JID, List[int]]]
+        expect_problems: Dict[JID, List[int]] = {}
 
         while True:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ include-package-data = false
 
 [tool.setuptools.dynamic]
 version = {attr = "prometheus_xmpp.__version__"}
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 requires-python = ">= 3.7"
 dependencies = [
     "slixmpp",
+    "slixmpp-omemo",
     "aiohttp",
     "pytz",
     "pyyaml",

--- a/xmpp-alerts.yml.example
+++ b/xmpp-alerts.yml.example
@@ -10,6 +10,11 @@ to_jid: 'jelmer@example.com'
 # List of JIDs that are allowed to query alerts and set silences. Defaults to
 # to_jid.
 amtool_allowed: []
+muc: no
+muc_jid: "example@groups.domain.com"
+muc_bot_nick: "PrometheusAlerts"
+omemo: no
+omemo_dir: ""
 
 # HTML message template as jinja2:
 # html_template: |


### PR DESCRIPTION
From @ichthyx in #40:

This PR add support for MUC (groupchat) and OMEMO (bot to user) and MUC OMEMO.

Currently private discussion (from user to bot) doesn't support omemo, we should implement omemo support in message() function. Not sure if I have the time for do it now, maybe later.

It add a new dependency which is slixmpp-omemo. Most of the code come from the slixmpp example : https://codeberg.org/poezio/slixmpp-omemo/src/branch/main/examples/echo_client.py

I used black to format code, it seems to have mess a lot of code, if you can suggest your way of formatting.
