### PR TITLE
fix bug in render_alert

### DIFF
--- a/prometheus_xmpp/__main__.py
+++ b/prometheus_xmpp/__main__.py
@@ -240,6 +240,7 @@ async def render_alert(text_template, html_template, alert):
             text = strip_html_tags(html)
     elif text_template:
         text = render_text_template(text_template, alert)
+        html = None
     else:
         text = render_text_template(DEFAULT_TEXT_TEMPLATE, alert)
         html = render_html_template(DEFAULT_HTML_TEMPLATE, alert)


### PR DESCRIPTION
return html but no variable is specified if text (which is default) and html optionnal so it's fix this bug

```
Traceback (most recent call last):
  File "/home/user/DEV/xmppprom/venv/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 462, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/DEV/xmppprom/venv/lib/python3.12/site-packages/aiohttp/web_app.py", line 537, in _handle
    resp = await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/DEV/xmppprom/prometheus-xmpp-alerts/prometheus_xmpp/__main__.py", line 249, in serve_test
    text, html = await render_alert(
                 ^^^^^^^^^^^^^^^^^^^
  File "/home/user/DEV/xmppprom/prometheus-xmpp-alerts/prometheus_xmpp/__main__.py", line 283, in render_alert
    return text, html
                 ^^^^
UnboundLocalError: cannot access local variable 'html' where it is not associated with a value
```