### PR TITLE
Send text-only messages to muc_jid

### DIFF
--- a/prometheus_xmpp/__main__.py
+++ b/prometheus_xmpp/__main__.py
@@ -278,10 +278,10 @@ async def serve_alert(request):
 
             try:
                 for mto, mtype in recipients:
-            if mtype == "groupchat":
-                xmpp_app.send_message(mto=mto, mbody=text, mtype="groupchat")
-            else:
-                xmpp_app.send_message(mto=mto, mbody=text, mhtml=html, mtype=mtype)
+                    if mtype == "groupchat":
+                        xmpp_app.send_message(mto=mto, mbody=text, mtype="groupchat")
+                    else:
+                        xmpp_app.send_message(mto=mto, mbody=text, mhtml=html, mtype=mtype)
             except slixmpp.xmlstream.xmlstream.NotConnectedError as e:
                 logging.warning("Alert posted but we are not online: %s", e)
                 last_alert_message_succeeded_gauge.set(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ prometheus-xmpp-alerts = "prometheus_xmpp.__main__:main"
 
 [project.optional-dependencies]
 testing = ["pytz"]
-dev = ["ruff==0.13.2"]
+dev = ["ruff==0.14.3"]
 
 [tool.setuptools]
 packages = ["prometheus_xmpp"]


### PR DESCRIPTION
When MUC_JID is defined and even added to XMPP_RECIPIENTS messages to muc-conference are not sent, probably due to lack of mhtml support in most of muc implementations. I've tried the patch offered on the latest prosody with muc and sending text-only messages to muc_jid works that way. Please could you review and add it up if possible.